### PR TITLE
fix to handle obj not having 'hasOwnProperty' function

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ originUrl.sync = options => {
 };
 
 function getKey(obj) {
-  if (obj.hasOwnProperty('remote "origin"')) {
+  let keys = Object.keys(obj);
+  if (keys.includes('remote "origin"')) {
     return 'remote "origin"';
   }
-  let keys = Object.keys(obj);
   return keys.find(key => /^remote /.test(key));
 }
 


### PR DESCRIPTION
I encountered an issue that I believe is caused by a recent change to the [ini](https://www.npmjs.com/package/ini) package (upon which [parse-git-config](https://www.npmjs.com/package/parse-git-config) depends). The ini package introduced the use of 'Object.create(null)' to create objects. (See https://github.com/npm/ini/commit/032fbaf5f0b98fce70c8cc380e0d05177a9c9073)

This PR is to change how the existence of obj keys is performed, to handle this change in 'ini'.